### PR TITLE
Use CD instead of using working-directory

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -65,7 +65,9 @@ jobs:
 
       - name: Terraform workspace
         id: workspace
-        run: terraform workspace select ${{ matrix.environment }}
+        run: |
+          cd ${{ matrix.environment }}
+          terraform workspace select ${{ matrix.environment }}
 
       - name: Terraform plan
         id: plan


### PR DESCRIPTION
working-directory seems to duplicate path elements for some reason: "An error occurred trying to start process '/usr/bin/bash' with working directory '/home/runner/work/data-streaming-platform-pipeline/data-streaming-platform-pipeline/./staging"