### PR TITLE
Remove the working-directory directive

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,7 +28,7 @@ jobs:
     defaults:
       run:
         shell: bash
-        working-directory: "./${{ matrix.environment }}"
+#        working-directory: "./${{ matrix.environment }}"
     steps:
       - name: Debug
         run: |


### PR DESCRIPTION
working-directory seems to duplicate path elements for some reason: "An error occurred trying to start process '/usr/bin/bash' with working directory '/home/runner/work/data-streaming-platform-pipeline/data-streaming-platform-pipeline/./staging"