### PR TITLE
Update terraform_version to 1.5.4

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Setup Terraform with specified version on the runner
         uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: 1.3.0
+          terraform_version: 1.5.4
 
       - name: Terraform init
         id: init


### PR DESCRIPTION
We need to be able to use the -or-create option for the "terraform workspace select" command