### PR TITLE
Use pull_request's closed event

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,9 +1,14 @@
 name: CD
 
+#on:
+#  push:
+#    branches:
+#      - 'main'
+
 on:
-  push:
-    branches:
-      - 'main'
+  pull_request:
+    types:
+      - closed
 
 env:
   # verbosity setting for Terraform logs
@@ -21,7 +26,7 @@ env:
 jobs:
   terraform_data_streaming_platform:
     name: "Terraform Data Streaming Platform"
-    #if: github.event.pull_request.merged
+    if: github.event.pull_request.merged
     strategy:
       max-parallel: 1
       matrix:


### PR DESCRIPTION
instead of main branch push to access the pull request which triggered the workflow.